### PR TITLE
Add postPhase method to control event phases across multiple busses

### DIFF
--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/TestModLauncher.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/TestModLauncher.java
@@ -14,6 +14,7 @@ import net.minecraftforge.eventbus.test.general.NonPublicEventHandler;
 import net.minecraftforge.eventbus.test.general.ParallelEventTest;
 import net.minecraftforge.eventbus.test.general.ParentHandlersGetInvokedTest;
 import net.minecraftforge.eventbus.test.general.ParentHandlersGetInvokedTestDummy;
+import net.minecraftforge.eventbus.test.general.PostPhaseTest;
 import net.minecraftforge.eventbus.test.general.ThreadedListenerExceptionTest;
 
 import org.junit.jupiter.api.Disabled;
@@ -89,6 +90,11 @@ public class TestModLauncher extends TestModLauncherBase {
     @Test
     public void parentHandlerGetsInvokedDummy() {
         doTest(new ParentHandlersGetInvokedTestDummy() {});
+    }
+
+    @Test
+    public void postPhase() {
+        doTest(new PostPhaseTest() {});
     }
 
     @RepeatedTest(100)

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/TestModLauncher.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/TestModLauncher.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import net.minecraftforge.eventbus.test.general.AbstractEventListenerTest;
 import net.minecraftforge.eventbus.test.general.DeadlockingEventTest;
 import net.minecraftforge.eventbus.test.general.EventBusSubtypeFilterTest;
+import net.minecraftforge.eventbus.test.general.EventClassCheckTest;
 import net.minecraftforge.eventbus.test.general.EventFiringEventTest;
 import net.minecraftforge.eventbus.test.general.EventHandlerExceptionTest;
 import net.minecraftforge.eventbus.test.general.GenericListenerTests;
@@ -52,6 +53,11 @@ public class TestModLauncher extends TestModLauncherBase {
     @Test
     public void eventHandlersCanFireEvents() {
         doTest(new EventFiringEventTest() {});
+    }
+
+    @Test
+    public void eventClassChecks() {
+        doTest(new EventClassCheckTest() {});
     }
 
     @Test

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/TestNoLoader.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/TestNoLoader.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import net.minecraftforge.eventbus.test.general.AbstractEventListenerTest;
 import net.minecraftforge.eventbus.test.general.DeadlockingEventTest;
 import net.minecraftforge.eventbus.test.general.EventBusSubtypeFilterTest;
+import net.minecraftforge.eventbus.test.general.EventClassCheckTest;
 import net.minecraftforge.eventbus.test.general.EventFiringEventTest;
 import net.minecraftforge.eventbus.test.general.EventHandlerExceptionTest;
 import net.minecraftforge.eventbus.test.general.GenericListenerTests;
@@ -58,6 +59,11 @@ public class TestNoLoader extends TestNoLoaderBase {
     @Test
     void eventHandlersCanFireEvents() {
         doTest(new EventFiringEventTest() {});
+    }
+
+    @Test
+    public void eventClassChecks() {
+        doTest(new EventClassCheckTest() {});
     }
 
     @Test

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/TestNoLoader.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/TestNoLoader.java
@@ -14,6 +14,7 @@ import net.minecraftforge.eventbus.test.general.NonPublicEventHandler;
 import net.minecraftforge.eventbus.test.general.ParallelEventTest;
 import net.minecraftforge.eventbus.test.general.ParentHandlersGetInvokedTest;
 import net.minecraftforge.eventbus.test.general.ParentHandlersGetInvokedTestDummy;
+import net.minecraftforge.eventbus.test.general.PostPhaseTest;
 import net.minecraftforge.eventbus.test.general.ThreadedListenerExceptionTest;
 
 import org.junit.jupiter.api.Disabled;
@@ -95,6 +96,11 @@ public class TestNoLoader extends TestNoLoaderBase {
     @Test
     public void parentHandlerGetsInvokedDummy() {
         doTest(new ParentHandlersGetInvokedTestDummy() {});
+    }
+
+    @Test
+    public void postPhase() {
+        doTest(new PostPhaseTest() {});
     }
 
     @RepeatedTest(100)

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/general/EventClassCheckTest.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/general/EventClassCheckTest.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.eventbus.test.general;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import net.minecraftforge.eventbus.api.BusBuilder;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.test.ITestHandler;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class EventClassCheckTest implements ITestHandler {
+    private interface IModBusEvent {}
+
+    public static class TestModBusEvent extends Event implements IModBusEvent {}
+    public static class TestForgeBusEvent extends Event {}
+
+    @Override
+    public void test(Consumer<Class<?>> validator, Supplier<BusBuilder> builder) {
+        var modBus = builder.get().markerType(IModBusEvent.class).build();
+        var forgeBus = builder.get().eventClassFilter(
+                eventClass -> !IModBusEvent.class.isAssignableFrom(eventClass),
+                eventClass -> "The Forge bus does not accept IModBusEvent subclasses, which " + eventClass + " is. Post it on the mod event bus instead."
+        ).build();
+
+        assertDoesNotThrow(() -> modBus.addListener((TestModBusEvent event) -> {}));
+        assertDoesNotThrow(() -> forgeBus.addListener((TestForgeBusEvent event) -> {}));
+        assertThrows(IllegalArgumentException.class, () -> modBus.addListener((TestForgeBusEvent event) -> {}));
+        assertThrows(IllegalArgumentException.class, () -> forgeBus.addListener((TestModBusEvent event) -> {}));
+    }
+}

--- a/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/general/PostPhaseTest.java
+++ b/eventbus-test/src/test/java/net/minecraftforge/eventbus/test/general/PostPhaseTest.java
@@ -1,0 +1,38 @@
+package net.minecraftforge.eventbus.test.general;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import net.minecraftforge.eventbus.api.BusBuilder;
+import net.minecraftforge.eventbus.api.Event;
+import net.minecraftforge.eventbus.api.EventPriority;
+import net.minecraftforge.eventbus.test.ITestHandler;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PostPhaseTest implements ITestHandler {
+    public static class TestEvent extends Event {}
+
+    @Override
+    public void test(Consumer<Class<?>> validator, Supplier<BusBuilder> builder) {
+        var counter = new AtomicInteger();
+
+        var busses = List.of(builder.get().build(), builder.get().build());
+
+        busses.get(0).addListener(EventPriority.LOW, (TestEvent event) -> assertEquals(2, counter.getAndIncrement()));
+        busses.get(0).addListener((TestEvent event) -> assertEquals(0, counter.getAndIncrement()));
+        busses.get(1).addListener((TestEvent event) -> assertEquals(1, counter.getAndIncrement()));
+
+        var event = new TestEvent();
+        for (var phase : EventPriority.values()) {
+            event.setPhase(phase);
+            for (var bus : busses) {
+                bus.postPhase(phase, event);
+            }
+        }
+
+        assertEquals(3, counter.get());
+    }
+}

--- a/src/main/java/net/minecraftforge/eventbus/BusBuilderImpl.java
+++ b/src/main/java/net/minecraftforge/eventbus/BusBuilderImpl.java
@@ -1,5 +1,8 @@
 package net.minecraftforge.eventbus;
 
+import java.util.function.Function;
+import java.util.function.Predicate;
+
 import net.minecraftforge.eventbus.api.BusBuilder;
 import net.minecraftforge.eventbus.api.Event;
 import net.minecraftforge.eventbus.api.IEventBus;
@@ -13,7 +16,8 @@ public final class BusBuilderImpl implements BusBuilder {
     boolean trackPhases = true;
     boolean startShutdown = false;
     boolean checkTypesOnDispatch = false;
-    Class<?> markerType = Event.class;
+    Predicate<Class<? extends Event>> eventFilter = eventClass -> true;
+    Function<Class<? extends Event>, String> errorMessageSupplier = eventClass -> "Unreachable";
     boolean modLauncher = false;
 
     @Override
@@ -41,9 +45,9 @@ public final class BusBuilderImpl implements BusBuilder {
     }
 
     @Override
-    public BusBuilder markerType(Class<?> type) {
-        if (!type.isInterface()) throw new IllegalArgumentException("Cannot specify a class marker type");
-        this.markerType = type;
+    public BusBuilder eventClassFilter(Predicate<Class<? extends Event>> filter, Function<Class<? extends Event>, String> errorMessageSupplier) {
+        this.eventFilter = filter;
+        this.errorMessageSupplier = errorMessageSupplier;
         return this;
     }
 

--- a/src/main/java/net/minecraftforge/eventbus/api/BusBuilder.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/BusBuilder.java
@@ -1,5 +1,8 @@
 package net.minecraftforge.eventbus.api;
 
+import java.util.function.Function;
+import java.util.function.Predicate;
+
 import net.minecraftforge.eventbus.BusBuilderImpl;
 
 /**
@@ -15,7 +18,14 @@ public interface BusBuilder {
     BusBuilder setExceptionHandler(IEventExceptionHandler handler);
     BusBuilder startShutdown();
     BusBuilder checkTypesOnDispatch();
-    BusBuilder markerType(Class<?> type);
+    default BusBuilder markerType(Class<?> type) {
+        if (!type.isInterface()) throw new IllegalArgumentException("Cannot specify a class marker type");
+        return eventClassFilter(
+                type::isAssignableFrom,
+                eventClass -> "This bus only accepts subclasses of " + type + ", which " + eventClass + " is not."
+        );
+    }
+    BusBuilder eventClassFilter(Predicate<Class<? extends Event>> filter, Function<Class<? extends Event>, String> errorMessageSupplier);
 
     /* Use ModLauncher hooks when creating ASM handlers. */
     BusBuilder useModLauncher();

--- a/src/main/java/net/minecraftforge/eventbus/api/IEventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/IEventBus.java
@@ -157,6 +157,15 @@ public interface IEventBus {
     boolean post(Event event, IEventBusInvokeDispatcher wrapper);
 
     /**
+     * Submit the event for dispatch to listeners that registered to a specific phase.
+     * {@link #post(Event)} should be preferred unless you know what you are doing.
+     *
+     * @param phase The phase for which the listeners should be invoked
+     * @param event The event to dispatch to listeners
+     */
+    void postPhase(EventPriority phase, Event event);
+
+    /**
      * Shuts down this event bus.
      *
      * No future events will be fired on this event bus, so any call to {@link #post(Event)} will be a no op after this method has been invoked


### PR DESCRIPTION
(Note: this includes #11, please see the second commit only)

Add a `postPhase` method that will allow us to fix event priorities across mod event busses in FML. See:
```java
var event = new TestEvent();
for (var phase : EventPriority.values()) {
    event.setPhase(phase);
    for (var bus : busses) {
        bus.postPhase(phase, event);
    }
}
```