### PR TITLE
Improve no-ASM performance

### DIFF
--- a/src/main/java/net/minecraftforge/eventbus/ASMEventHandler.java
+++ b/src/main/java/net/minecraftforge/eventbus/ASMEventHandler.java
@@ -66,7 +66,7 @@ public class ASMEventHandler implements IEventListener {
     {
         if (handler != null)
         {
-            if (!event.isCancelable() || !event.isCanceled() || subInfo.receiveCanceled())
+            if (!event.isCanceled() || subInfo.receiveCanceled())
             {
                 if (filter == null || filter == ((IGenericEvent)event).getGenericType())
                 {

--- a/src/main/java/net/minecraftforge/eventbus/ClassLoaderFactory.java
+++ b/src/main/java/net/minecraftforge/eventbus/ClassLoaderFactory.java
@@ -18,7 +18,7 @@ public class ClassLoaderFactory implements IEventListenerFactory {
     private static final String HANDLER_DESC = Type.getInternalName(IEventListener.class);
     private static final String HANDLER_FUNC_DESC = Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(Event.class));
     private static final ASMClassLoader LOADER = new ASMClassLoader();
-    private static final LockHelper<Method, Class<?>> cache = new LockHelper<>(new HashMap<>());
+    private static final LockHelper<Method, Class<?>> cache = new LockHelper<>(HashMap::new);
 
     @Override
     public IEventListener create(Method method, Object target) throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException, ClassNotFoundException {

--- a/src/main/java/net/minecraftforge/eventbus/ClassLoaderFactory.java
+++ b/src/main/java/net/minecraftforge/eventbus/ClassLoaderFactory.java
@@ -3,7 +3,6 @@ package net.minecraftforge.eventbus;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.HashMap;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Type;
@@ -18,7 +17,7 @@ public class ClassLoaderFactory implements IEventListenerFactory {
     private static final String HANDLER_DESC = Type.getInternalName(IEventListener.class);
     private static final String HANDLER_FUNC_DESC = Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(Event.class));
     private static final ASMClassLoader LOADER = new ASMClassLoader();
-    private static final LockHelper<Method, Class<?>> cache = new LockHelper<>(HashMap::new);
+    private static final LockHelper<Method, Class<?>> cache = LockHelper.withHashMap();
 
     @Override
     public IEventListener create(Method method, Object target) throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException, SecurityException, ClassNotFoundException {

--- a/src/main/java/net/minecraftforge/eventbus/EventBus.java
+++ b/src/main/java/net/minecraftforge/eventbus/EventBus.java
@@ -158,7 +158,7 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
     }
 
     private <T extends Event> Predicate<T> passCancelled(final boolean ignored) {
-        return e-> ignored || !e.isCancelable() || !e.isCanceled();
+        return e-> ignored || !e.isCanceled();
     }
 
     private <T extends GenericEvent<? extends F>, F> Predicate<T> passGenericFilter(Class<F> type) {
@@ -340,7 +340,7 @@ public class EventBus implements IEventExceptionHandler, IEventBus {
             exceptionHandler.handleException(this, event, listeners, index, throwable);
             throw throwable;
         }
-        return event.isCancelable() && event.isCanceled();
+        return event.isCanceled();
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/eventbus/LockHelper.java
+++ b/src/main/java/net/minecraftforge/eventbus/LockHelper.java
@@ -24,7 +24,7 @@ public class LockHelper<K,V> {
 
     public LockHelper(IntFunction<Map<K, V>> mapConstructor) {
         this.mapConstructor = mapConstructor;
-        this.backingMap = mapConstructor.apply(0);
+        this.backingMap = mapConstructor.apply(32); // reasonable initial size
     }
 
     private Map<K, V> getReadMap() {

--- a/src/main/java/net/minecraftforge/eventbus/LockHelper.java
+++ b/src/main/java/net/minecraftforge/eventbus/LockHelper.java
@@ -2,6 +2,8 @@ package net.minecraftforge.eventbus;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -13,6 +15,15 @@ import java.util.function.Supplier;
  * yet still manages to properly deal with many threads.
  */
 public class LockHelper<K,V> {
+    public static <K, V> LockHelper<K, V> withHashMap() {
+        // convert size to capacity according to default load factor
+        return new LockHelper<>(size -> new HashMap<>((size + 2) * 4 / 3));
+    }
+
+    public static <K, V> LockHelper<K, V> withIdentityHashMap() {
+        return new LockHelper<>(IdentityHashMap::new);
+    }
+
     private final IntFunction<Map<K, V>> mapConstructor;
     /**
      * Only modify this map while holding the lock object!
@@ -22,7 +33,7 @@ public class LockHelper<K,V> {
     private volatile Map<K, V> readOnlyView = null;
     private Object lock = new Object();
 
-    public LockHelper(IntFunction<Map<K, V>> mapConstructor) {
+    private LockHelper(IntFunction<Map<K, V>> mapConstructor) {
         this.mapConstructor = mapConstructor;
         this.backingMap = mapConstructor.apply(32); // reasonable initial size
     }

--- a/src/main/java/net/minecraftforge/eventbus/ModLauncherFactory.java
+++ b/src/main/java/net/minecraftforge/eventbus/ModLauncherFactory.java
@@ -1,7 +1,6 @@
 package net.minecraftforge.eventbus;
 
 import java.lang.reflect.Method;
-import java.util.HashMap;
 import java.util.Optional;
 import org.objectweb.asm.tree.ClassNode;
 
@@ -9,7 +8,7 @@ import cpw.mods.modlauncher.Launcher;
 import cpw.mods.modlauncher.api.IModuleLayerManager;
 
 public class ModLauncherFactory extends ClassLoaderFactory {
-    private static final LockHelper<String, Method> PENDING = new LockHelper<>(HashMap::new);
+    private static final LockHelper<String, Method> PENDING = LockHelper.withHashMap();
     private Optional<ClassLoader> gameClassLoader = null;
 
     @Override

--- a/src/main/java/net/minecraftforge/eventbus/ModLauncherFactory.java
+++ b/src/main/java/net/minecraftforge/eventbus/ModLauncherFactory.java
@@ -9,7 +9,7 @@ import cpw.mods.modlauncher.Launcher;
 import cpw.mods.modlauncher.api.IModuleLayerManager;
 
 public class ModLauncherFactory extends ClassLoaderFactory {
-    private static final LockHelper<String, Method> PENDING = new LockHelper<>(new HashMap<>());
+    private static final LockHelper<String, Method> PENDING = new LockHelper<>(HashMap::new);
     private Optional<ClassLoader> gameClassLoader = null;
 
     @Override

--- a/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
@@ -32,10 +32,10 @@ import java.util.function.Function;
 
 public class EventListenerHelper
 {
-    private static final LockHelper<Class<?>, ListenerList> listeners = new LockHelper<>(new IdentityHashMap<>());
+    private static final LockHelper<Class<?>, ListenerList> listeners = new LockHelper<>(IdentityHashMap::new);
     private static final ListenerList EVENTS_LIST = new ListenerList();
-    private static final LockHelper<Class<?>, Boolean> cancelable = new LockHelper<>(new IdentityHashMap<>());
-    private static final LockHelper<Class<?>, Boolean> hasResult = new LockHelper<>(new IdentityHashMap<>());
+    private static final LockHelper<Class<?>, Boolean> cancelable = new LockHelper<>(IdentityHashMap::new);
+    private static final LockHelper<Class<?>, Boolean> hasResult = new LockHelper<>(IdentityHashMap::new);
     /**
      * Returns a {@link ListenerList} object that contains all listeners
      * that are registered to this event class.

--- a/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
+++ b/src/main/java/net/minecraftforge/eventbus/api/EventListenerHelper.java
@@ -27,15 +27,13 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
-import java.util.IdentityHashMap;
-import java.util.function.Function;
 
 public class EventListenerHelper
 {
-    private static final LockHelper<Class<?>, ListenerList> listeners = new LockHelper<>(IdentityHashMap::new);
+    private static final LockHelper<Class<?>, ListenerList> listeners = LockHelper.withIdentityHashMap();
     private static final ListenerList EVENTS_LIST = new ListenerList();
-    private static final LockHelper<Class<?>, Boolean> cancelable = new LockHelper<>(IdentityHashMap::new);
-    private static final LockHelper<Class<?>, Boolean> hasResult = new LockHelper<>(IdentityHashMap::new);
+    private static final LockHelper<Class<?>, Boolean> cancelable = LockHelper.withIdentityHashMap();
+    private static final LockHelper<Class<?>, Boolean> hasResult = LockHelper.withIdentityHashMap();
     /**
      * Returns a {@link ListenerList} object that contains all listeners
      * that are registered to this event class.


### PR DESCRIPTION
New benchmark:
```
Benchmark                                              Mode  Cnt   Score    Error  Units
EventBusBenchmark.testClassLoaderCombined              avgt   15  84.617 ▒ 18.165  ns/op
EventBusBenchmark.testClassLoaderCombined:Àstack       avgt          NaN             ---
EventBusBenchmark.testClassLoaderDynamic               avgt   15  32.792 ▒  8.370  ns/op
EventBusBenchmark.testClassLoaderDynamic:Àstack        avgt          NaN             ---
EventBusBenchmark.testClassLoaderLambda                avgt   15  34.561 ▒  9.503  ns/op
EventBusBenchmark.testClassLoaderLambda:Àstack         avgt          NaN             ---
EventBusBenchmark.testClassLoaderStatic                avgt   15  31.085 ▒  7.756  ns/op
EventBusBenchmark.testClassLoaderStatic:Àstack         avgt          NaN             ---
EventBusBenchmark.testModLauncherCombined              avgt   15  77.762 ▒ 16.132  ns/op
EventBusBenchmark.testModLauncherCombined:Àstack       avgt          NaN             ---
EventBusBenchmark.testModLauncherDynamic               avgt   15  32.783 ▒  7.823  ns/op
EventBusBenchmark.testModLauncherDynamic:Àstack        avgt          NaN             ---
EventBusBenchmark.testModLauncherLambda                avgt   15  36.079 ▒  8.600  ns/op
EventBusBenchmark.testModLauncherLambda:Àstack         avgt          NaN             ---
EventBusBenchmark.testModLauncherStatic                avgt   15  30.572 ▒  7.573  ns/op
EventBusBenchmark.testModLauncherStatic:Àstack         avgt          NaN             ---
EventBusBenchmarkNoLoader.testNoLoaderCombined         avgt   15  88.453 ▒  6.768  ns/op
EventBusBenchmarkNoLoader.testNoLoaderCombined:Àstack  avgt          NaN             ---
EventBusBenchmarkNoLoader.testNoLoaderDynamic          avgt   15  40.793 ▒  3.335  ns/op
EventBusBenchmarkNoLoader.testNoLoaderDynamic:Àstack   avgt          NaN             ---
EventBusBenchmarkNoLoader.testNoLoaderLambda           avgt   15  43.646 ▒  5.980  ns/op
EventBusBenchmarkNoLoader.testNoLoaderLambda:Àstack    avgt          NaN             ---
EventBusBenchmarkNoLoader.testNoLoaderStatic           avgt   15  38.414 ▒  3.822  ns/op
EventBusBenchmarkNoLoader.testNoLoaderStatic:Àstack    avgt          NaN             ---
```

This shows that the ASM subclass transformer doesn't meaningfully change the performance numbers.