### PR TITLE
Store listener lists inside the EventBus

### DIFF
--- a/bus-test/src/test/java/net/neoforged/bus/test/Whitebox.java
+++ b/bus-test/src/test/java/net/neoforged/bus/test/Whitebox.java
@@ -16,9 +16,11 @@ public class Whitebox {
     }
 
     @SuppressWarnings("unchecked")
-    public static <T> T invokeMethod(final Object obj, final String methodName) {
+    public static <T> T invokeMethod(final Object obj, final String methodName, Object... args) {
         try {
-            return (T)Arrays.stream(obj.getClass().getMethods()).filter(m->m.getName().equals(methodName)).findFirst().orElseThrow().invoke(obj);
+            var method = Arrays.stream(obj.getClass().getDeclaredMethods()).filter(m->m.getName().equals(methodName)).findFirst().orElseThrow();
+            method.setAccessible(true);
+            return (T)method.invoke(obj, args);
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }

--- a/bus-test/src/test/java/net/neoforged/bus/test/general/DeadlockingEventTest.java
+++ b/bus-test/src/test/java/net/neoforged/bus/test/general/DeadlockingEventTest.java
@@ -2,7 +2,6 @@ package net.neoforged.bus.test.general;
 
 import net.neoforged.bus.api.BusBuilder;
 import net.neoforged.bus.api.Event;
-import net.neoforged.bus.api.EventListenerHelper;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.bus.test.ITestHandler;
@@ -35,7 +34,6 @@ public class DeadlockingEventTest implements ITestHandler {
 
     @Override
     public void after() {
-        Whitebox.invokeMethod(EventListenerHelper.class, "clearAll");
         final HashSet<AbstractQueuedSynchronizer> workers = Whitebox.getInternalState(THREAD_POOL, "workers");
         final List<Thread> threads = workers.stream().map(w -> Whitebox.<Thread>getInternalState(w, "thread")).collect(Collectors.toList());
         threads.stream().map(Thread::getStackTrace).forEach(ts->LogManager.getLogger().info("\n"+stack(ts)));
@@ -63,7 +61,6 @@ public class DeadlockingEventTest implements ITestHandler {
             final Class<? extends Event> clz = getClass("ChildEvent");
             Thread.sleep(0, nanos);
             LogManager.getLogger().info(System.nanoTime() - start);
-            assertEquals(clz.getConstructor().newInstance().getListenerList(), EventListenerHelper.getListenerList(clz));
             LogManager.getLogger().info("Task 2");
             return null;
         };

--- a/bus-test/src/test/java/net/neoforged/bus/test/general/ParallelEventTest.java
+++ b/bus-test/src/test/java/net/neoforged/bus/test/general/ParallelEventTest.java
@@ -43,9 +43,8 @@ public abstract class ParallelEventTest implements ITestHandler {
 
             // Make sure it tracked them all
             busSet.forEach(bus -> {
-                int busid = Whitebox.getInternalState(bus, "busID");
-                ListenerList afterAdd = Whitebox.invokeMethod(new DummyEvent.GoodEvent(), "getListenerList");
-                assertEquals(LISTENER_COUNT, afterAdd.getListeners(busid).length, "Failed to register all event handlers");
+                ListenerList afterAdd = Whitebox.invokeMethod(bus, "getListenerList", DummyEvent.GoodEvent.class);
+                assertEquals(LISTENER_COUNT, afterAdd.getListeners().length, "Failed to register all event handlers");
             });
 
             busSet.parallelStream().forEach(iEventBus -> { //post events parallel
@@ -70,9 +69,8 @@ public abstract class ParallelEventTest implements ITestHandler {
             toAdd.parallelStream().forEach(Runnable::run); //execute parallel listener adding
 
             // Make sure it tracked them all
-            int busid = Whitebox.getInternalState(bus, "busID");
-            ListenerList afterAdd = Whitebox.invokeMethod(new DummyEvent.GoodEvent(), "getListenerList");
-            assertEquals(LISTENER_COUNT, afterAdd.getListeners(busid).length, "Failed to register all event handlers");
+            ListenerList afterAdd = Whitebox.invokeMethod(bus, "getListenerList", DummyEvent.GoodEvent.class);
+            assertEquals(LISTENER_COUNT, afterAdd.getListeners().length, "Failed to register all event handlers");
 
             toAdd = new HashSet<>();
             for (int i = 0; i < RUN_ITERATIONS; i++) //prepare parallel event posting

--- a/src/main/java/net/neoforged/bus/ListenerList.java
+++ b/src/main/java/net/neoforged/bus/ListenerList.java
@@ -21,7 +21,6 @@ package net.neoforged.bus;
 
 import net.neoforged.bus.api.EventPriority;
 import net.neoforged.bus.api.IEventListener;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,247 +29,109 @@ import java.util.List;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
 
-
-public class ListenerList
-{
-    private static List<ListenerList> allLists = new ArrayList<>();
-    private static int maxSize = 0;
-
-    @Nullable
+public class ListenerList {
+    private boolean rebuild = true;
+    private AtomicReference<IEventListener[]> listeners = new AtomicReference<>();
+    private ArrayList<ArrayList<IEventListener>> priorities;
     private ListenerList parent;
-    private ListenerListInst[] lists = new ListenerListInst[0];
+    private List<ListenerList> children;
+    private Semaphore writeLock = new Semaphore(1, true);
 
-    public ListenerList()
-    {
-        this(null);
+    ListenerList() {
+        int count = EventPriority.values().length;
+        priorities = new ArrayList<>(count);
+
+        for (int x = 0; x < count; x++) {
+            priorities.add(new ArrayList<>());
+        }
     }
 
-    public ListenerList(@Nullable ListenerList parent)
-    {
-        // parent needs to be set before resize !
+
+    ListenerList(ListenerList parent) {
+        this();
         this.parent = parent;
-        extendMasterList(this);
-        resizeLists(maxSize);
+        this.parent.addChild(this);
     }
 
-    private synchronized static void extendMasterList(ListenerList inst)
-    {
-        allLists.add(inst);
+    /**
+     * Returns a ArrayList containing all listeners for this event,
+     * and all parent events for the specified priority.
+     * <p>
+     * The list is returned with the listeners for the children events first.
+     *
+     * @param priority The Priority to get
+     * @return ArrayList containing listeners
+     */
+    public ArrayList<IEventListener> getListeners(EventPriority priority) {
+        writeLock.acquireUninterruptibly();
+        ArrayList<IEventListener> ret = new ArrayList<>(priorities.get(priority.ordinal()));
+        writeLock.release();
+        if (parent != null) {
+            ret.addAll(parent.getListeners(priority));
+        }
+        return ret;
     }
 
-    static void resize(int max)
-    {
-        if (max > maxSize)
-        {
-            synchronized (ListenerList.class)
-            {
-                if (max > maxSize)
-                {
-                    allLists.forEach(list -> list.resizeLists(max));
-                    maxSize = max;
-                }
+    /**
+     * Returns a full list of all listeners for all priority levels.
+     * Including all parent listeners.
+     * <p>
+     * List is returned in proper priority order.
+     * <p>
+     * Automatically rebuilds the internal Array cache if its information is out of date.
+     *
+     * @return Array containing listeners
+     */
+    public IEventListener[] getListeners() {
+        if (shouldRebuild()) buildCache();
+        return listeners.get();
+    }
+
+    protected boolean shouldRebuild() {
+        return rebuild;// || (parent != null && parent.shouldRebuild());
+    }
+
+    protected void forceRebuild() {
+        this.rebuild = true;
+        if (this.children != null) {
+            synchronized (this.children) {
+                for (ListenerList child : this.children)
+                    child.forceRebuild();
             }
         }
     }
 
-    private synchronized void resizeLists(int max)
-    {
-        if (parent != null)
-        {
-            parent.resizeLists(max);
-        }
-
-        if (lists.length >= max)
-        {
-            return;
-        }
-
-        ListenerListInst[] newList = new ListenerListInst[max];
-        int x = 0;
-        for (; x < lists.length; x++)
-        {
-            newList[x] = lists[x];
-        }
-        for(; x < max; x++)
-        {
-            if (parent != null)
-            {
-                newList[x] = new ListenerListInst(parent.getInstance(x));
-            }
-            else
-            {
-                newList[x] = new ListenerListInst();
-            }
-        }
-        lists = newList;
+    private void addChild(ListenerList child) {
+        if (this.children == null)
+            this.children = Collections.synchronizedList(new ArrayList<>(2));
+        this.children.add(child);
     }
 
-    public static synchronized void clearBusID(int id)
-    {
-        for (ListenerList list : allLists)
-        {
-            list.lists[id].dispose();
+    /**
+     * Rebuild the local Array of listeners, returns early if there is no work to do.
+     */
+    private void buildCache() {
+        if (parent != null && parent.shouldRebuild()) {
+            parent.buildCache();
         }
+        ArrayList<IEventListener> ret = new ArrayList<>();
+        Arrays.stream(EventPriority.values()).forEach(value -> {
+            ret.addAll(getListeners(value));
+        });
+        this.listeners.set(ret.toArray(new IEventListener[0]));
+        rebuild = false;
     }
 
-    protected ListenerListInst getInstance(int id)
-    {
-        return lists[id];
+    public void register(EventPriority priority, IEventListener listener) {
+        writeLock.acquireUninterruptibly();
+        priorities.get(priority.ordinal()).add(listener);
+        writeLock.release();
+        this.forceRebuild();
     }
 
-    public IEventListener[] getListeners(int id)
-    {
-        return lists[id].getListeners();
-    }
-
-    public void register(int id, EventPriority priority, IEventListener listener)
-    {
-        lists[id].register(priority, listener);
-    }
-
-    public void unregister(int id, IEventListener listener)
-    {
-        lists[id].unregister(listener);
-    }
-
-    public static synchronized void unregisterAll(int id, IEventListener listener)
-    {
-        for (ListenerList list : allLists)
-        {
-            list.unregister(id, listener);
-        }
-    }
-
-    private class ListenerListInst
-    {
-        private boolean rebuild = true;
-        private AtomicReference<IEventListener[]> listeners = new AtomicReference<>();
-        private ArrayList<ArrayList<IEventListener>> priorities;
-        private ListenerListInst parent;
-        private List<ListenerListInst> children;
-        private Semaphore writeLock = new Semaphore(1, true);
-
-
-        private ListenerListInst()
-        {
-            int count = EventPriority.values().length;
-            priorities = new ArrayList<>(count);
-
-            for (int x = 0; x < count; x++)
-            {
-                priorities.add(new ArrayList<>());
-            }
-        }
-
-        public void dispose()
-        {
-            writeLock.acquireUninterruptibly();
-            priorities.forEach(ArrayList::clear);
-            priorities.clear();
-            writeLock.release();
-            parent = null;
-            listeners = null;
-            if (children != null)
-                children.clear();
-        }
-
-        private ListenerListInst(ListenerListInst parent)
-        {
-            this();
-            this.parent = parent;
-            this.parent.addChild(this);
-        }
-
-        /**
-         * Returns a ArrayList containing all listeners for this event,
-         * and all parent events for the specified priority.
-         *
-         * The list is returned with the listeners for the children events first.
-         *
-         * @param priority The Priority to get
-         * @return ArrayList containing listeners
-         */
-        public ArrayList<IEventListener> getListeners(EventPriority priority)
-        {
-            writeLock.acquireUninterruptibly();
-            ArrayList<IEventListener> ret = new ArrayList<>(priorities.get(priority.ordinal()));
-            writeLock.release();
-            if (parent != null)
-            {
-                ret.addAll(parent.getListeners(priority));
-            }
-            return ret;
-        }
-
-        /**
-         * Returns a full list of all listeners for all priority levels.
-         * Including all parent listeners.
-         *
-         * List is returned in proper priority order.
-         *
-         * Automatically rebuilds the internal Array cache if its information is out of date.
-         *
-         * @return Array containing listeners
-         */
-        public IEventListener[] getListeners()
-        {
-            if (shouldRebuild()) buildCache();
-            return listeners.get();
-        }
-
-        protected boolean shouldRebuild()
-        {
-            return rebuild;// || (parent != null && parent.shouldRebuild());
-        }
-
-        protected void forceRebuild()
-        {
-            this.rebuild = true;
-            if (this.children != null) {
-                synchronized (this.children) {
-                    for (ListenerListInst child : this.children)
-                        child.forceRebuild();
-                }
-            }
-        }
-
-        private void addChild(ListenerListInst child)
-        {
-            if (this.children == null)
-                this.children = Collections.synchronizedList(new ArrayList<>(2));
-            this.children.add(child);
-        }
-
-        /**
-         * Rebuild the local Array of listeners, returns early if there is no work to do.
-         */
-        private void buildCache()
-        {
-            if(parent != null && parent.shouldRebuild())
-            {
-                parent.buildCache();
-            }
-            ArrayList<IEventListener> ret = new ArrayList<>();
-            Arrays.stream(EventPriority.values()).forEach(value -> {
-                ret.addAll(getListeners(value));
-            });
-            this.listeners.set(ret.toArray(new IEventListener[0]));
-            rebuild = false;
-        }
-
-        public void register(EventPriority priority, IEventListener listener)
-        {
-            writeLock.acquireUninterruptibly();
-            priorities.get(priority.ordinal()).add(listener);
-            writeLock.release();
-            this.forceRebuild();
-        }
-
-        public void unregister(IEventListener listener)
-        {
-            writeLock.acquireUninterruptibly();
-            priorities.stream().filter(list -> list.remove(listener)).forEach(list -> this.forceRebuild());
-            writeLock.release();
-        }
+    public void unregister(IEventListener listener) {
+        writeLock.acquireUninterruptibly();
+        priorities.stream().filter(list -> list.remove(listener)).forEach(list -> this.forceRebuild());
+        writeLock.release();
     }
 }

--- a/src/main/java/net/neoforged/bus/ListenerList.java
+++ b/src/main/java/net/neoforged/bus/ListenerList.java
@@ -73,14 +73,12 @@ public class ListenerList {
     }
 
     /**
-     * Returns a full list of all listeners for all priority levels.
+     * {@return a full list of all listeners for all priority levels}
      * Including all parent listeners.
      * <p>
      * List is returned in proper priority order.
      * <p>
      * Automatically rebuilds the internal Array cache if its information is out of date.
-     *
-     * @return Array containing listeners
      */
     public IEventListener[] getListeners() {
         if (shouldRebuild()) buildCache();
@@ -88,7 +86,7 @@ public class ListenerList {
     }
 
     protected boolean shouldRebuild() {
-        return rebuild;// || (parent != null && parent.shouldRebuild());
+        return rebuild;
     }
 
     protected void forceRebuild() {

--- a/src/main/java/net/neoforged/bus/LockHelper.java
+++ b/src/main/java/net/neoforged/bus/LockHelper.java
@@ -38,7 +38,7 @@ public class LockHelper<K,V> {
         this.backingMap = mapConstructor.apply(32); // reasonable initial size
     }
 
-    private Map<K, V> getReadMap() {
+    Map<K, V> getReadMap() {
         var map = readOnlyView;
         if (map == null) {
             // Need to update the read map

--- a/src/main/java/net/neoforged/bus/api/Event.java
+++ b/src/main/java/net/neoforged/bus/api/Event.java
@@ -19,8 +19,6 @@
 
 package net.neoforged.bus.api;
 
-import net.neoforged.bus.ListenerList;
-
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -121,14 +119,5 @@ public class Event
             );
         }
         result = value;
-    }
-
-    /**
-     * Returns a ListenerList object that contains all listeners
-     * that are registered to this event.
-     */
-    public final ListenerList getListenerList()
-    {
-        return EventListenerHelper.getListenerListInternal(this.getClass(), true);
     }
 }

--- a/src/main/java/net/neoforged/bus/api/EventListenerHelper.java
+++ b/src/main/java/net/neoforged/bus/api/EventListenerHelper.java
@@ -19,78 +19,15 @@
 
 package net.neoforged.bus.api;
 
-import net.neoforged.bus.ListenerList;
 import net.neoforged.bus.LockHelper;
 import net.neoforged.bus.api.Event.HasResult;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Modifier;
 
 public class EventListenerHelper
 {
-    private static final LockHelper<Class<?>, ListenerList> listeners = LockHelper.withIdentityHashMap();
-    private static final ListenerList EVENTS_LIST = new ListenerList();
     private static final LockHelper<Class<?>, Boolean> cancelable = LockHelper.withIdentityHashMap();
     private static final LockHelper<Class<?>, Boolean> hasResult = LockHelper.withIdentityHashMap();
-    /**
-     * Returns a {@link ListenerList} object that contains all listeners
-     * that are registered to this event class.
-     *
-     * This supports abstract classes that cannot be instantiated.
-     *
-     * Note: this is much slower than the instance method {@link Event#getListenerList()}.
-     * For performance when emitting events, always call that method instead.
-     */
-    public static ListenerList getListenerList(Class<?> eventClass)
-    {
-        return getListenerListInternal(eventClass, false);
-    }
-
-    static ListenerList getListenerListInternal(Class<?> eventClass, boolean fromInstanceCall)
-    {
-        if (eventClass == Event.class) return EVENTS_LIST; // Small optimization, bypasses all the locks/maps.
-
-        // Skip allocating lambda if possible
-        var list = listeners.get(eventClass);
-        if (list != null)
-            return list;
-
-        return listeners.computeIfAbsent(eventClass, () -> computeListenerList(eventClass, fromInstanceCall));
-    }
-
-    private static ListenerList computeListenerList(Class<?> eventClass, boolean fromInstanceCall)
-    {
-        if (eventClass == Event.class)
-        {
-            return new ListenerList();
-        }
-
-        if (fromInstanceCall || Modifier.isAbstract(eventClass.getModifiers()))
-        {
-            Class<?> superclass = eventClass.getSuperclass();
-            ListenerList parentList = getListenerList(superclass);
-            return new ListenerList(parentList);
-        }
-
-        try
-        {
-            Constructor<?> ctr = eventClass.getConstructor();
-            ctr.setAccessible(true);
-            Event event = (Event) ctr.newInstance();
-            return event.getListenerList();
-        }
-        catch (NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e)
-        {
-            throw new RuntimeException("Error computing listener list for " + eventClass.getName(), e);
-        }
-    }
-
-    @SuppressWarnings("unused") // Used in DeadlockingEventTest
-    private static void clearAll() {
-        listeners.clearAll();
-    }
 
     static boolean isCancelable(Class<?> eventClass) {
         return hasAnnotation(eventClass, Cancelable.class, cancelable);


### PR DESCRIPTION
Benchmarks shows similar if not better performance:

```
Benchmark                                              Mode  Cnt   Score    Error  Units
EventBusBenchmark.testClassLoaderCombined              avgt   15  73.054 ± 22.724  ns/op
EventBusBenchmark.testClassLoaderCombined:·stack       avgt          NaN             ---
EventBusBenchmark.testClassLoaderDynamic               avgt   15  30.681 ±  0.873  ns/op
EventBusBenchmark.testClassLoaderDynamic:·stack        avgt          NaN             ---
EventBusBenchmark.testClassLoaderLambda                avgt   15  32.367 ±  2.214  ns/op
EventBusBenchmark.testClassLoaderLambda:·stack         avgt          NaN             ---
EventBusBenchmark.testClassLoaderStatic                avgt   15  30.204 ±  2.599  ns/op
EventBusBenchmark.testClassLoaderStatic:·stack         avgt          NaN             ---
EventBusBenchmark.testModLauncherCombined              avgt   15  64.087 ±  1.757  ns/op
EventBusBenchmark.testModLauncherCombined:·stack       avgt          NaN             ---
EventBusBenchmark.testModLauncherDynamic               avgt   15  31.168 ±  0.494  ns/op
EventBusBenchmark.testModLauncherDynamic:·stack        avgt          NaN             ---
EventBusBenchmark.testModLauncherLambda                avgt   15  31.201 ±  0.565  ns/op
EventBusBenchmark.testModLauncherLambda:·stack         avgt          NaN             ---
EventBusBenchmark.testModLauncherStatic                avgt   15  28.732 ±  1.052  ns/op
EventBusBenchmark.testModLauncherStatic:·stack         avgt          NaN             ---
EventBusBenchmarkNoLoader.testNoLoaderCombined         avgt   15  65.787 ±  1.878  ns/op
EventBusBenchmarkNoLoader.testNoLoaderCombined:·stack  avgt          NaN             ---
EventBusBenchmarkNoLoader.testNoLoaderDynamic          avgt   15  31.424 ±  4.117  ns/op
EventBusBenchmarkNoLoader.testNoLoaderDynamic:·stack   avgt          NaN             ---
EventBusBenchmarkNoLoader.testNoLoaderLambda           avgt   15  32.635 ±  4.949  ns/op
EventBusBenchmarkNoLoader.testNoLoaderLambda:·stack    avgt          NaN             ---
EventBusBenchmarkNoLoader.testNoLoaderStatic           avgt   15  29.688 ±  3.934  ns/op
EventBusBenchmarkNoLoader.testNoLoaderStatic:·stack    avgt          NaN             ---
```