### PR TITLE
Rework ModLauncher classloading hacks to preserve static fields between test runs

### DIFF
--- a/bus-test/src/test/java/net/neoforged/bus/test/TestModLauncherBase.java
+++ b/bus-test/src/test/java/net/neoforged/bus/test/TestModLauncherBase.java
@@ -11,8 +11,6 @@ import java.lang.invoke.MethodType;
 import org.junit.jupiter.api.BeforeAll;
 
 public class TestModLauncherBase {
-    private static final String CLASS_NAME = "test.modlauncher.class";
-    private static final String METHOD_NAME = "test.modlauncher.method";
     private static final String RUNNING_TEST = "test.modlauncher.running";
 
     private static TransformingClassLoader classLoader;


### PR DESCRIPTION
Trust me, it works!

Same hack as before, but using the same `TransformingClassLoader` every time. This preserves static fields between test runs, and thus the thread pool from one of the tests is reused... this avoids spamming our TC server with new threads until it decides to fail the run due to excessive resource allocation.

JUnit added a nice launcher API that we could use if we wanted all tests to run with a specific class loader, but unfortunately we also want some tests (the NoLoader) to run with the normal app class loader.