### PR TITLE
Respect `@SubscribeEvent.receiveCanceled`

### DIFF
--- a/bus-test/src/test/java/net/neoforged/bus/test/TestNoLoader.java
+++ b/bus-test/src/test/java/net/neoforged/bus/test/TestNoLoader.java
@@ -99,6 +99,11 @@ public class TestNoLoader extends TestNoLoaderBase {
     }
 
     @Test
+    public void testCancelledEvent() {
+        doTest(new CancelledEventTest() {});
+    }
+
+    @Test
     public void testAbstractEventClasses() {
         doTest(new AbstractEventClassesTest() {});
     }

--- a/bus-test/src/test/java/net/neoforged/bus/test/general/CancelledEventTest.java
+++ b/bus-test/src/test/java/net/neoforged/bus/test/general/CancelledEventTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.bus.test.general;
+
+import net.neoforged.bus.api.BusBuilder;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.bus.test.ITestHandler;
+import net.neoforged.bus.testjar.DummyEvent;
+
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CancelledEventTest implements ITestHandler {
+    @Override
+    public void test(Supplier<BusBuilder> builder) {
+        IEventBus bus = builder.get().build();
+
+        Listener listener = new Listener();
+        bus.register(listener);
+
+        DummyEvent.CancellableEvent event = new DummyEvent.CancellableEvent();
+        event.setCanceled(true);
+        bus.post(event);
+
+        assertTrue(listener.receivedCanceled, "Received the canceled event");
+    }
+
+    public static class Listener {
+
+        boolean receivedCanceled = false;
+
+        @SubscribeEvent(receiveCanceled = true)
+        public void onEvent(DummyEvent.CancellableEvent event) {
+            this.receivedCanceled = true;
+        }
+
+    }
+}

--- a/src/main/java/net/neoforged/bus/SubscribeEventListener.java
+++ b/src/main/java/net/neoforged/bus/SubscribeEventListener.java
@@ -45,7 +45,7 @@ public final class SubscribeEventListener extends EventListener implements IWrap
         if (handler != null)
         {
             // The cast is safe because the check is removed if the event is not cancellable
-            if (!((ICancellableEvent) event).isCanceled()) {
+            if (subInfo.receiveCanceled() || !((ICancellableEvent) event).isCanceled()) {
                 handler.invoke(event);
             }
         }


### PR DESCRIPTION
Re-adds the dropped bypass, that was accidentally dropped in https://github.com/neoforged/Bus/pull/20

Fixes https://github.com/neoforged/Bus/issues/32