### PR TITLE
Allow registering static `Method`s through `register`

### DIFF
--- a/bus-test/src/test/java/net/neoforged/bus/test/TestNoLoader.java
+++ b/bus-test/src/test/java/net/neoforged/bus/test/TestNoLoader.java
@@ -94,6 +94,11 @@ public class TestNoLoader extends TestNoLoaderBase {
     }
 
     @Test
+    public void testMethodEventHandler() {
+        doTest(new MethodEventHandlerTest() {});
+    }
+
+    @Test
     public void testCommonSubscribeEventErrors() {
         doTest(new CommonSubscribeEventErrorsTest() {});
     }

--- a/bus-test/src/test/java/net/neoforged/bus/test/general/MethodEventHandlerTest.java
+++ b/bus-test/src/test/java/net/neoforged/bus/test/general/MethodEventHandlerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) NeoForged and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+
+package net.neoforged.bus.test.general;
+
+import net.neoforged.bus.api.BusBuilder;
+import net.neoforged.bus.api.Event;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.bus.test.ITestHandler;
+
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MethodEventHandlerTest implements ITestHandler {
+    @Override
+    public void test(Supplier<BusBuilder> builder) {
+        final var bus = builder.get().build();
+
+        assertDoesNotThrow(() -> bus.register(Listener.class.getDeclaredMethod("onEvent", TestEvent.class)));
+
+        final var event = new TestEvent();
+        bus.post(event);
+        assertTrue(event.wasReceived, "event received");
+
+        assertThrows(IllegalArgumentException.class, () -> bus.register(Listener.class.getDeclaredMethod("nonStaticOnEvent", TestEvent.class)));
+        assertThrows(IllegalArgumentException.class, () -> bus.register(Listener.class.getDeclaredMethod("nonAnnotatedOnEvent", TestEvent.class)));
+    }
+
+    static class TestEvent extends Event {
+        boolean wasReceived;
+    }
+
+    private static class Listener {
+        @SubscribeEvent
+        static void onEvent(TestEvent testEvent) {
+            testEvent.wasReceived = true;
+        }
+
+        @SubscribeEvent
+        void nonStaticOnEvent(TestEvent testEvent) {
+
+        }
+
+        static void nonAnnotatedOnEvent(TestEvent testEvent) {
+
+        }
+    }
+}

--- a/src/main/java/net/neoforged/bus/api/IEventBus.java
+++ b/src/main/java/net/neoforged/bus/api/IEventBus.java
@@ -20,6 +20,7 @@
 package net.neoforged.bus.api;
 
 import java.util.function.Consumer;
+import java.lang.reflect.Method;
 
 /**
  * EventBus API.
@@ -28,8 +29,8 @@ import java.util.function.Consumer;
  */
 public interface IEventBus {
     /**
-     * Register an instance object or a Class, and add listeners for all {@link SubscribeEvent} annotated methods
-     * found there.
+     * Register an instance object or a {@linkplain Class}, and add listeners for all {@link SubscribeEvent} annotated methods
+     * found there, or directly a {@linkplain Method} annotated with {@link SubscribeEvent}.
      *
      * Depending on what is passed as an argument, different listener creation behaviour is performed.
      *
@@ -37,12 +38,16 @@ public interface IEventBus {
      *     <dt>Object Instance</dt>
      *     <dd>Scanned for <em>non-static</em> methods annotated with {@link SubscribeEvent} and creates listeners for
      *     each method found.</dd>
-     *     <dt>Class Instance</dt>
+     *     <dt>{@linkplain Class} Instance</dt>
      *     <dd>Scanned for <em>static</em> methods annotated with {@link SubscribeEvent} and creates listeners for
      *     each method found.</dd>
+     *     <dt>{@linkplain Method} Instance</dt>
+     *     <dd>Expects a static method annotated with {@link SubscribeEvent} which will be registered as a listener for the {@linkplain Event}
+     *     type it has as its sole parameter.</dd>
      * </dl>
      *
      * @param target Either a {@link Class} instance or an arbitrary object, for scanning and event listener creation
+     *               or a {@linkplain Method}
      */
     void register(Object target);
 
@@ -141,7 +146,7 @@ public interface IEventBus {
      *
      * NOTE: Consumers can be stored in a variable if unregistration is required for the Consumer.
      *
-     * @param object The object, {@link Class} or {@link Consumer} to unsubscribe.
+     * @param object The object, {@linkplain Class}, {@linkplain Method} or {@link Consumer} to unsubscribe.
      */
     void unregister(Object object);
 


### PR DESCRIPTION
This PR adds another special-case to `register(Object)`, allowing the direct registration of static `Method` instances annotated with `@SubscribeEvent` (and respecting the parameter contract). This change will facilitate the removal of the need to specify a bus in `@EventBusSubscriber` as FML can decide by itself which bus to register to each method separately.